### PR TITLE
Hortense updates plus facilitating use of own GEOSgcm_GridComp

### DIFF
--- a/GEOSldas/build_scripts/g5_modules
+++ b/GEOSldas/build_scripts/g5_modules
@@ -1,29 +1,34 @@
 #!/bin/csh -f
 
-set basedir_version = v6.2.8
+set basedir_version = v6.2.13
 
 set node = `uname -n`
 module purge
-if (($node =~ r0* ) || ($node =~ login* )) then
-    echo "Loading modules for Tier-1 (broadwell)..."
-    set basedir_path = /scratch/leuven/projects/lt1_2020_es_pilot/project_input/ldas/GEOSldas_libraries
-    module unuse /apps/leuven/broadwell/2016a/modules/all
-    module unuse /apps/leuven/broadwell/2018a/modules/all
-else if (($node =~ r1* )) then
-    echo "Loading modules for Tier-1 (skylake)..."
-    set basedir_path = /scratch/leuven/projects/lt1_2020_es_pilot/project_input/ldas/GEOSldas_libraries
-    module unuse /apps/leuven/skylake/2016a/modules/all
-    module unuse /apps/leuven/skylake/2018a/modules/all
-else
+if ( $node =~ tier2* ) then
     echo "Loading modules for Tier-2..."
     set basedir_path = /staging/leuven/stg_00024/GEOSldas_libraries
     module unuse /apps/leuven/skylake/2018a/modules/all
     module unuse /apps/leuven/cascadelake/2018a/modules/all
     module unuse /apps/leuven/cascadelake/2019b/modules/all
     module use /apps/leuven/skylake/2019b/modules/all
+    module load foss flex Bison CMake Autotools texinfo gomkl Python/2.7.16-GCCcore8.3.0
+else if ( $node =~ *dodrio* ) then 
+    echo "Loading modules for Hortense Tier-1..."
+    set basedir_path = /dodrio/scratch/projects/2022_200/project_input/ldas/GEOSldas_libraries
+    module --force purge
+    module load cluster/dodrio/cpu_rome
+    module load foss flex/2.6.4-GCCcore-11.3.0 
+    module load Bison 
+    module load CMake 
+    module load Autotools 
+    module load texinfo 
+    module load Python/2.7.18-GCCcore-11.3.0-bare 
+    module load libtirpc/1.3.2-GCCcore-11.3.0 
+    module load imkl/2022.1.0
+else 
+    echo "Platform not found ... exit"
+    exit 1
 endif
 
-module load foss flex Bison CMake Autotools texinfo gomkl Python/2.7.16-GCCcore-8.3.0
-
-setenv BASEDIR $basedir_path/ESMA-Baselibs-$basedir_version/src
+setenv BASEDIR $basedir_path/ESMA-Baselibs-$basedir_version
 setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$BASEDIR/Linux/lib

--- a/GEOSldas/build_scripts/g5_modules
+++ b/GEOSldas/build_scripts/g5_modules
@@ -1,10 +1,11 @@
 #!/bin/csh -f
 
-set basedir_version = v6.2.13
+#set basedir_version = v6.2.8 # working for tier-1 and tier-2 
+set basedir_version = v6.2.13 # currently working for tier-1 only
 
 set node = `uname -n`
 module purge
-if ( $node =~ tier2* ) then
+if (( $node =~ tier2* ) || ( $node =~ r* )) then
     echo "Loading modules for Tier-2..."
     set basedir_path = /staging/leuven/stg_00024/GEOSldas_libraries
     module unuse /apps/leuven/skylake/2018a/modules/all
@@ -14,7 +15,7 @@ if ( $node =~ tier2* ) then
     module load foss flex Bison CMake Autotools texinfo gomkl Python/2.7.16-GCCcore8.3.0
 else if ( $node =~ *dodrio* ) then 
     echo "Loading modules for Hortense Tier-1..."
-    set basedir_path = /dodrio/scratch/projects/2022_200/project_input/ldas/GEOSldas_libraries
+    set basedir_path = /dodrio/scratch/projects/2022_200/project_input/rsda/ldas/GEOSldas_libraries
     module --force purge
     module load cluster/dodrio/cpu_rome
     module load foss flex/2.6.4-GCCcore-11.3.0 
@@ -30,5 +31,10 @@ else
     exit 1
 endif
 
-setenv BASEDIR $basedir_path/ESMA-Baselibs-$basedir_version
-setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$BASEDIR/Linux/lib
+if (( $basedir_version =~ v6.2.8 )) then
+    setenv BASEDIR $basedir_path/ESMA-Baselibs-$basedir_version/src/Linux
+    setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$BASEDIR/lib
+else 
+    setenv BASEDIR $basedir_path/ESMA-Baselibs-$basedir_version/Linux
+    setenv LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:$BASEDIR/lib
+endif

--- a/GEOSldas/build_scripts/get_build_GEOSldas.bash
+++ b/GEOSldas/build_scripts/get_build_GEOSldas.bash
@@ -1,32 +1,45 @@
 #!/bin/bash
 
-ldas_root=/data/leuven/320/vsc32046/src_code
-ldas_version=17.11.0
+#ldas_root=/staging/leuven/stg_00024/OUTPUT/michelb/src_code
+#ldas_version=17.11.0 # requires baselibs 8.2.8, working on tier-1 and tier-2
+ldas_root=/dodrio/scratch/projects/2022_200/project_output/rsda/vsc31786/src_code
+ldas_version=17.11.1 # requires baselibs 8.2.13 only working on tier-1 currently
+
+if [[ $CONDA_DEFAULT_ENV == "" ]]; then
+    echo "no python conda environment loaded ...."
+    echo "loading py3 of Michel ..."
+    source activate /data/leuven/317/vsc31786/miniconda/envs/py3
+fi
+
 # IMPORTANT: GEOSldas is pulled from the RSDA-KUL github repository,
 # where a branch named ${ldas_version}_KUL is assumed to exist!
 
-baselibs_version=v6.2.8
+if [[ $ldas_version == "17.11.0" ]]; then
+    baselibs_version=v6.2.8
+elif [[ $ldas_version == "17.11.1" ]]; then
+    baselibs_version=v6.2.13
+fi
 # IMPORTANT: staging is not cross-mounted, so the baselibs are installed at a
 # different location on Tier-1!
 
 # Set paths for Tier-1 or Tier-2
 node=`uname -n`
-if [[ $node == "r"[0-1]* ]] || [[ $node == "login"* ]]; then
-    baselibs_root=/scratch/leuven/projects/lt1_2020_es_pilot/project_input/ldas/GEOSldas_libraries
-    ldas_dirname=GEOSldas_${ldas_version}_Tier1_skylake
-    module load git
-else
+if [[ $node == *"tier2"* ]] || [[ $node == "r"* ]]; then
     baselibs_root=/staging/leuven/stg_00024/GEOSldas_libraries
     ldas_dirname=GEOSldas_${ldas_version}_Tier2
+elif [[ $node == *"dodrio"* ]]; then
+    baselibs_root=/dodrio/scratch/projects/2022_200/project_input/rsda/ldas/GEOSldas_libraries
+    ldas_dirname=GEOSldas_${ldas_version}
+    module load git
 fi
 
 # Check if LDAS directory already exists, otherwise pull from GitHub
 cd $ldas_root
 if [ ! -d "$ldas_dirname" ]; then
     git clone -b v${ldas_version}_KUL --single-branch git@github.com:KUL-RSDA/GEOSldas.git $ldas_dirname
+    # or a user branch:
+    # git clone -b v${ldas_version}_TN_KUL --single-branch git@github.com:mbechtold/GEOSldas.git $ldas_dirname
     cd $ldas_dirname
-    git remote rename origin upstream
-    git remote add origin git@github.com:GEOS-ESM/GEOSldas.git
     mepo init
     mepo clone
     cp $baselibs_root/g5_modules ./@env/
@@ -63,22 +76,37 @@ fi
 
 # Load modules for Tier-1 or Tier-2
 module purge
-if [[ $node == "r0"* ]] || [[ $node == "login"* ]]; then
-    module unuse /apps/leuven/broadwell/2016a/modules/all
-    module unuse /apps/leuven/broadwell/2018a/modules/all
-elif [[ $node == "r1"* ]]; then
-    module unuse /apps/leuven/skylake/2016a/modules/all
-    module unuse /apps/leuven/skylake/2018a/modules/all
-else
+if [[ $node == *"tier2"* ]] || [[ $node == "r"* ]] ; then
+    # Load modules for Tier-2
     module unuse /apps/leuven/skylake/2018a/modules/all
     module unuse /apps/leuven/cascadelake/2018a/modules/all
     module unuse /apps/leuven/cascadelake/2019b/modules/all
     module use /apps/leuven/skylake/2019b/modules/all
+    module load foss flex Bison CMake Autotools texinfo gomkl Python/2.7.16-GCCcore-8.3.0
+elif [[ $node == *"dodrio"* ]]; then
+    # Load modules for Tier-1 UGENT on Hortense
+    module --force purge
+    module load cluster/dodrio/cpu_rome
+    module load foss 
+    module load flex/2.6.4-GCCcore-11.3.0 
+    module load Bison 
+    module load CMake 
+    module load Autotools 
+    module load texinfo 
+    module load Python/2.7.18-GCCcore-11.3.0-bare 
+    module load libtirpc/1.3.2-GCCcore-11.3.0 
+    module load imkl/2022.1.0
+else
+    echo "Platform not known ... stopping"
+    exit 1
 fi
-module load foss flex Bison CMake Autotools texinfo gomkl Python/2.7.16-GCCcore-8.3.0
 
 # Set required environmental variables for GEOSldas build
-export BASEDIR=$baselibs_root/ESMA-Baselibs-${baselibs_version}/src/Linux
+if [[ $baselibs_version == "v6.2.8" ]]; then
+    export BASEDIR=$baselibs_root/ESMA-Baselibs-${baselibs_version}/src/Linux
+else
+    export BASEDIR=$baselibs_root/ESMA-Baselibs-${baselibs_version}/Linux
+fi
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$BASEDIR/lib
 
 # Build and install

--- a/GEOSldas/build_scripts/get_build_GEOSldas.bash
+++ b/GEOSldas/build_scripts/get_build_GEOSldas.bash
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-#ldas_root=/staging/leuven/stg_00024/OUTPUT/michelb/src_code
-#ldas_version=17.11.0 # requires baselibs 8.2.8, working on tier-1 and tier-2
+ldas_version=17.11.1 # requires baselibs 8.2.13 only working on tier-1 currently, 17.11.0 working also for tier-2
 ldas_root=/dodrio/scratch/projects/2022_200/project_output/rsda/vsc31786/src_code
-ldas_version=17.11.1 # requires baselibs 8.2.13 only working on tier-1 currently
+ldas_dirname=GEOSldas_${ldas_version} # GEOSldas_${ldas_version}_TN
+GEOSldas_repo=KUL-RSDA/GEOSldas.git  # mbechtold/GEOSldas.git
+GEOSldas_branch=v${ldas_version}_KUL  # v${ldas_version}_TN_KUL
 
 if [[ $CONDA_DEFAULT_ENV == "" ]]; then
     echo "no python conda environment loaded ...."
@@ -26,19 +27,15 @@ fi
 node=`uname -n`
 if [[ $node == *"tier2"* ]] || [[ $node == "r"* ]]; then
     baselibs_root=/staging/leuven/stg_00024/GEOSldas_libraries
-    ldas_dirname=GEOSldas_${ldas_version}_Tier2
 elif [[ $node == *"dodrio"* ]]; then
     baselibs_root=/dodrio/scratch/projects/2022_200/project_input/rsda/ldas/GEOSldas_libraries
-    ldas_dirname=GEOSldas_${ldas_version}
     module load git
 fi
 
 # Check if LDAS directory already exists, otherwise pull from GitHub
 cd $ldas_root
 if [ ! -d "$ldas_dirname" ]; then
-    git clone -b v${ldas_version}_KUL --single-branch git@github.com:KUL-RSDA/GEOSldas.git $ldas_dirname
-    # or a user branch:
-    # git clone -b v${ldas_version}_TN_KUL --single-branch git@github.com:mbechtold/GEOSldas.git $ldas_dirname
+    git clone -b $GEOSldas_branch --single-branch git@github.com:$GEOSldas_repo $ldas_dirname
     cd $ldas_dirname
     mepo init
     mepo clone

--- a/GEOSldas/build_scripts/get_build_baselibs.bash
+++ b/GEOSldas/build_scripts/get_build_baselibs.bash
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-version=6.2.13
+version=6.2.8 # working for tier-1 and tier-2
+#version=6.2.13 # working only fier tier-1 currently (texinfo needed for 2021 tier-2 toolchain)
+
 # IMPORTANT: staging is not cross-mounted, so the baselibs are installed at a
 # different location on Tier-1!
 
@@ -13,18 +15,25 @@ fi
 # Load modules and set paths for Tier-1 or Tier-2
 node=`uname -n`
 module purge
-if [[ $node == "tier2"* ]]; then 
-    echo "Loading modules for Tier-2..."
+if [[ $node == "tier2"* ]] | [[ $node == "r"* ]]; then 
     root=/staging/leuven/stg_00024/GEOSldas_libraries
+    if [ -d "${root}/ESMA-Baselibs-v${version}" ]; then
+        echo "$root/ESMA-Baselibs-v${version} already exists, first delete ... stopping."
+        exit 1
+    fi
+    mkdir -p $root/ESMA-Baselibs-v${version}
+    echo "Loading modules for Tier-2..."
     module unuse /apps/leuven/skylake/2018a/modules/all
     module unuse /apps/leuven/cascadelake/2018a/modules/all
     module unuse /apps/leuven/cascadelake/2019b/modules/all
     module use /apps/leuven/skylake/2019b/modules/all
     module load foss flex Bison CMake Autotools texinfo
 elif [[ $node == *"dodrio"* ]]; then
-    echo "Deleting old baselib compilation run of this version"
-    root=/dodrio/scratch/projects/2022_200/project_input/ldas/GEOSldas_libraries
-    rm -rf $root/ESMA-Baselibs-v${version}
+    root=/dodrio/scratch/projects/2022_200/project_input/rsda/ldas/GEOSldas_libraries
+    if [ -d "${root}/ESMA-Baselibs-v${version}" ]; then
+        echo "$root/ESMA-Baselibs-v${version} already exists, first delete ... stopping."
+        exit 1
+    fi
     mkdir -p $root/ESMA-Baselibs-v${version}
     echo "Loading modules for Hortense Tier-1..."
     module --force purge
@@ -44,15 +53,23 @@ rm -f ESMA-Baselibs-v${version}.COMPLETE.tar.xz
 cd $root/ESMA-Baselibs-v${version}
 
 # temporary fix since 6.2.13 baselibs were not complete: getting full FLAP from 6.2.8
-rm -r $root/ESMA-Baselibs-v${version}/FLAP
-cd $root
-wget https://github.com/GEOS-ESM/ESMA-Baselibs/releases/download/v6.2.8/ESMA-Baselibs-v6.2.8.COMPLETE.tar.xz
-tar -xf ESMA-Baselibs-v6.2.8.COMPLETE.tar.xz
-rm -f ESMA-Baselibs-v6.2.8.COMPLETE.tar.xz
-cp -r ESMA-Baselibs-v6.2.8/src/FLAP ESMA-Baselibs-v${version}/.
-rm -rf ESMA-Baselibs-v6.2.8
+if [[ $version == "6.2.13" ]]; then
+    rm -r $root/ESMA-Baselibs-v${version}/FLAP
+    mkdir $root/temp
+    cd $root/temp
+    wget https://github.com/GEOS-ESM/ESMA-Baselibs/releases/download/v6.2.8/ESMA-Baselibs-v6.2.8.COMPLETE.tar.xz
+    tar -xf ESMA-Baselibs-v6.2.8.COMPLETE.tar.xz
+    rm -f ESMA-Baselibs-v6.2.8.COMPLETE.tar.xz
+    cp -r ESMA-Baselibs-v6.2.8/src/FLAP $root/ESMA-Baselibs-v${version}/.
+    cd $root
+    rm -rf $root/temp
+fi
 
-cd $root/ESMA-Baselibs-v${version}
+if [[ $version == "6.2.8" ]]; then
+    cd $root/ESMA-Baselibs-v${version}/src
+elif [[ $version == "6.2.13" ]]; then
+    cd $root/ESMA-Baselibs-v${version}
+fi
 mkdir Linux
 if [[ $node == *"dodrio"* ]]; then
     # tirpc library in strange place for hortense, added to Arch.mk to be found
@@ -63,7 +80,11 @@ fi
 
 # Build Baselibs
 export FC=gfortran
-make install ESMF_COMM=openmpi prefix=$root/ESMA-Baselibs-v${version}/Linux
+if [[ $version == "6.2.8" ]]; then
+    make install ESMF_COMM=openmpi prefix=$root/ESMA-Baselibs-v${version}/src/Linux
+elif [[ $version == "6.2.13" ]]; then
+    make install ESMF_COMM=openmpi prefix=$root/ESMA-Baselibs-v${version}/Linux
+fi
 
 # This is just to check if the installation succeeded for all the modules.
 export ESMF_COMM=openmpi

--- a/GEOSldas/build_scripts/get_build_baselibs.bash
+++ b/GEOSldas/build_scripts/get_build_baselibs.bash
@@ -1,43 +1,69 @@
 #!/bin/bash
 
-version=6.2.8
+version=6.2.13
 # IMPORTANT: staging is not cross-mounted, so the baselibs are installed at a
 # different location on Tier-1!
+
+if [[ $CONDA_DEFAULT_ENV == "" ]]; then
+    echo "no python conda environment loaded ...."
+    echo "loading py3 of Michel ..."
+    source activate /data/leuven/317/vsc31786/miniconda/envs/py3
+fi
 
 # Load modules and set paths for Tier-1 or Tier-2
 node=`uname -n`
 module purge
-if [[ $node == "r0"* ]] || [[ $node == "login"* ]]; then
-    echo "Loading modules for Tier-1 (broadwell)..."
-    root=/scratch/leuven/projects/lt1_2020_es_pilot/project_input/ldas/GEOSldas_libraries
-    module unuse /apps/leuven/broadwell/2016a/modules/all
-    module unuse /apps/leuven/broadwell/2018a/modules/all
-elif [[ $node == "r1"* ]]; then
-    echo "Loading modules for Tier-1 (skylake)..."
-    root=/scratch/leuven/projects/lt1_2020_es_pilot/project_input/ldas/GEOSldas_libraries
-    module unuse /apps/leuven/skylake/2016a/modules/all
-    module unuse /apps/leuven/skylake/2018a/modules/all
-else
+if [[ $node == "tier2"* ]]; then 
     echo "Loading modules for Tier-2..."
     root=/staging/leuven/stg_00024/GEOSldas_libraries
     module unuse /apps/leuven/skylake/2018a/modules/all
     module unuse /apps/leuven/cascadelake/2018a/modules/all
     module unuse /apps/leuven/cascadelake/2019b/modules/all
     module use /apps/leuven/skylake/2019b/modules/all
+    module load foss flex Bison CMake Autotools texinfo
+elif [[ $node == *"dodrio"* ]]; then
+    echo "Deleting old baselib compilation run of this version"
+    root=/dodrio/scratch/projects/2022_200/project_input/ldas/GEOSldas_libraries
+    rm -rf $root/ESMA-Baselibs-v${version}
+    mkdir -p $root/ESMA-Baselibs-v${version}
+    echo "Loading modules for Hortense Tier-1..."
+    module --force purge
+    module load cluster/dodrio/cpu_rome
+    module load foss flex/2.6.4-GCCcore-11.3.0 Bison CMake Autotools texinfo libtirpc/1.3.2-GCCcore-11.3.0
+else
+    echo "Unknown platform ... stopping"
+    exit 1
 fi
-module load foss flex Bison CMake Autotools texinfo
 
 # Download Baselibs from GitHub
 cd $root
 wget https://github.com/GEOS-ESM/ESMA-Baselibs/releases/download/v${version}/ESMA-Baselibs-v${version}.COMPLETE.tar.xz
 tar -xf ESMA-Baselibs-v${version}.COMPLETE.tar.xz
 rm -f ESMA-Baselibs-v${version}.COMPLETE.tar.xz
-cd ESMA-Baselibs-v${version}/src
+# for version 6.2.13
+cd $root/ESMA-Baselibs-v${version}
+
+# temporary fix since 6.2.13 baselibs were not complete: getting full FLAP from 6.2.8
+rm -r $root/ESMA-Baselibs-v${version}/FLAP
+cd $root
+wget https://github.com/GEOS-ESM/ESMA-Baselibs/releases/download/v6.2.8/ESMA-Baselibs-v6.2.8.COMPLETE.tar.xz
+tar -xf ESMA-Baselibs-v6.2.8.COMPLETE.tar.xz
+rm -f ESMA-Baselibs-v6.2.8.COMPLETE.tar.xz
+cp -r ESMA-Baselibs-v6.2.8/src/FLAP ESMA-Baselibs-v${version}/.
+rm -rf ESMA-Baselibs-v6.2.8
+
+cd $root/ESMA-Baselibs-v${version}
 mkdir Linux
+if [[ $node == *"dodrio"* ]]; then
+    # tirpc library in strange place for hortense, added to Arch.mk to be found
+    find Arch.mk -type f -exec sed -i '/Fedora/i # To find tirpc on Hortense' {} \;
+    find Arch.mk -type f -exec sed -i '/Fedora/i INC_EXTRA += -I$(EBROOTLIBTIRPC)\/include\/tirpc' {} \;
+    find Arch.mk -type f -exec sed -i '/Fedora/i LIB_EXTRA += -ltirpc' {} \;
+fi
 
 # Build Baselibs
 export FC=gfortran
-make install ESMF_COMM=openmpi prefix=$root/ESMA-Baselibs-v${version}/src/Linux
+make install ESMF_COMM=openmpi prefix=$root/ESMA-Baselibs-v${version}/Linux
 
 # This is just to check if the installation succeeded for all the modules.
 export ESMF_COMM=openmpi


### PR DESCRIPTION
This PR includes recent updates from @sebastian-a-swm and @mbechtold to the GEOSldas compilation scripts to:
- enable the migration from Breniac to Hortense (including cleanup for the EOL of Breniac), 
- and facilitate the use of own GEOSgcm_GridComp branches.
