### PR TITLE
ENH: Change to GCCcore 11.2 and py3 removed for baselibs compil because not needed

### DIFF
--- a/GEOSldas/build_scripts/g5_modules
+++ b/GEOSldas/build_scripts/g5_modules
@@ -18,13 +18,14 @@ else if ( $node =~ *dodrio* ) then
     set basedir_path = /dodrio/scratch/projects/2022_200/project_input/rsda/ldas/GEOSldas_libraries
     module --force purge
     module load cluster/dodrio/cpu_rome
-    module load foss flex/2.6.4-GCCcore-11.3.0 
-    module load Bison 
-    module load CMake 
-    module load Autotools 
-    module load texinfo 
-    module load Python/2.7.18-GCCcore-11.3.0-bare 
-    module load libtirpc/1.3.2-GCCcore-11.3.0 
+    module load foss/2021b 
+    module load flex/2.6.4-GCCcore-11.2.0 
+    module load Bison/3.7.6-GCCcore-11.2.0 
+    module load CMake/3.22.1-GCCcore-11.2.0 
+    module load Autotools/20210726-GCCcore-11.2.0 
+    module load texinfo/6.8-GCCcore-11.2.0 
+    module load libtirpc/1.3.2-GCCcore-11.2.0
+    module load Python/2.7.18-GCCcore-11.2.0
     module load imkl/2022.1.0
 else 
     echo "Platform not found ... exit"

--- a/GEOSldas/build_scripts/get_build_GEOSldas.bash
+++ b/GEOSldas/build_scripts/get_build_GEOSldas.bash
@@ -84,14 +84,14 @@ elif [[ $node == *"dodrio"* ]]; then
     # Load modules for Tier-1 UGENT on Hortense
     module --force purge
     module load cluster/dodrio/cpu_rome
-    module load foss 
-    module load flex/2.6.4-GCCcore-11.3.0 
-    module load Bison 
-    module load CMake 
-    module load Autotools 
-    module load texinfo 
-    module load Python/2.7.18-GCCcore-11.3.0-bare 
-    module load libtirpc/1.3.2-GCCcore-11.3.0 
+    module load foss/2021b
+    module load flex/2.6.4-GCCcore-11.2.0
+    module load Bison/3.7.6-GCCcore-11.2.0
+    module load CMake/3.22.1-GCCcore-11.2.0
+    module load Autotools/20210726-GCCcore-11.2.0
+    module load texinfo/6.8-GCCcore-11.2.0
+    module load libtirpc/1.3.2-GCCcore-11.2.0
+    module load Python/2.7.18-GCCcore-11.2.0
     module load imkl/2022.1.0
 else
     echo "Platform not known ... stopping"

--- a/GEOSldas/build_scripts/get_build_GEOSldas.bash
+++ b/GEOSldas/build_scripts/get_build_GEOSldas.bash
@@ -2,9 +2,9 @@
 
 ldas_version=17.11.1 # requires baselibs 8.2.13 only working on tier-1 currently, 17.11.0 working also for tier-2
 ldas_root=/dodrio/scratch/projects/2022_200/project_output/rsda/vsc31786/src_code
-ldas_dirname=GEOSldas_${ldas_version} # GEOSldas_${ldas_version}_TN
-GEOSldas_repo=KUL-RSDA/GEOSldas.git  # mbechtold/GEOSldas.git
-GEOSldas_branch=v${ldas_version}_KUL  # v${ldas_version}_TN_KUL
+ldas_dirname=GEOSldas_${ldas_version}_TN_seb # GEOSldas_${ldas_version}_TN
+GEOSldas_repo=sebastian-a-swm/GEOSldas.git  # mbechtold/GEOSldas.git
+GEOSldas_branch=v${ldas_version}_TN_KUL  # v${ldas_version}_TN_KUL
 
 if [[ $CONDA_DEFAULT_ENV == "" ]]; then
     echo "no python conda environment loaded ...."

--- a/GEOSldas/build_scripts/get_build_baselibs.bash
+++ b/GEOSldas/build_scripts/get_build_baselibs.bash
@@ -1,16 +1,10 @@
 #!/bin/bash
 
-version=6.2.8 # working for tier-1 and tier-2
-#version=6.2.13 # working only fier tier-1 currently (texinfo needed for 2021 tier-2 toolchain)
+#version=6.2.8 # working for tier-1 and tier-2
+version=6.2.13 # working only fier tier-1 currently (texinfo needed for 2021 tier-2 toolchain)
 
 # IMPORTANT: staging is not cross-mounted, so the baselibs are installed at a
 # different location on Tier-1!
-
-if [[ $CONDA_DEFAULT_ENV == "" ]]; then
-    echo "no python conda environment loaded ...."
-    echo "loading py3 of Michel ..."
-    source activate /data/leuven/317/vsc31786/miniconda/envs/py3
-fi
 
 # Load modules and set paths for Tier-1 or Tier-2
 node=`uname -n`
@@ -38,7 +32,13 @@ elif [[ $node == *"dodrio"* ]]; then
     echo "Loading modules for Hortense Tier-1..."
     module --force purge
     module load cluster/dodrio/cpu_rome
-    module load foss flex/2.6.4-GCCcore-11.3.0 Bison CMake Autotools texinfo libtirpc/1.3.2-GCCcore-11.3.0
+    module load foss/2021b 
+    module load flex/2.6.4-GCCcore-11.2.0 
+    module load Bison/3.7.6-GCCcore-11.2.0 
+    module load CMake/3.22.1-GCCcore-11.2.0 
+    module load Autotools/20210726-GCCcore-11.2.0 
+    module load texinfo/6.8-GCCcore-11.2.0 
+    module load libtirpc/1.3.2-GCCcore-11.2.0
 else
     echo "Unknown platform ... stopping"
     exit 1


### PR DESCRIPTION
ldas_setup needs dateutil module from python which is only provided for python modules of GCCcore 11.2 on Hortense. Therefore we ran the compilation now with GCCcore 11.2 instead of the default 11.3. 