### PR TITLE
ENH: v17.12.0 compilation on Hortense

### DIFF
--- a/GEOSldas/build_scripts/g5_modules
+++ b/GEOSldas/build_scripts/g5_modules
@@ -1,7 +1,7 @@
 #!/bin/csh -f
 
 #set basedir_version = v6.2.8 # working for tier-1 and tier-2 
-set basedir_version = v6.2.13 # currently working for tier-1 only
+set basedir_version = v7.7.0 # currently working for tier-1 only
 
 set node = `uname -n`
 module purge

--- a/GEOSldas/build_scripts/get_build_GEOSldas.bash
+++ b/GEOSldas/build_scripts/get_build_GEOSldas.bash
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-ldas_version=17.11.1 # requires baselibs 8.2.13 only working on tier-1 currently, 17.11.0 working also for tier-2
+ldas_version=17.12.0 # requires baselibs 8.2.13 only working on tier-1 currently, 17.11.0 working also for tier-2
 ldas_root=/dodrio/scratch/projects/2022_200/project_output/rsda/vsc31786/src_code
-ldas_dirname=GEOSldas_${ldas_version}_TN_seb # GEOSldas_${ldas_version}_TN
-GEOSldas_repo=sebastian-a-swm/GEOSldas.git  # mbechtold/GEOSldas.git
-GEOSldas_branch=v${ldas_version}_TN_KUL  # v${ldas_version}_TN_KUL
+ldas_dirname=GEOSldas_${ldas_version}_KUL # GEOSldas_${ldas_version}_TN
+GEOSldas_repo=kul-rsda/GEOSldas.git #sebastian-a-swm/GEOSldas.git  # mbechtold/GEOSldas.git
+GEOSldas_branch=v${ldas_version}_KUL  # v${ldas_version}_TN_KUL
 
 if [[ $CONDA_DEFAULT_ENV == "" ]]; then
     echo "no python conda environment loaded ...."
@@ -19,6 +19,8 @@ if [[ $ldas_version == "17.11.0" ]]; then
     baselibs_version=v6.2.8
 elif [[ $ldas_version == "17.11.1" ]]; then
     baselibs_version=v6.2.13
+elif [[ $ldas_version == "17.12.0" ]]; then
+    baselibs_version=v7.7.0
 fi
 # IMPORTANT: staging is not cross-mounted, so the baselibs are installed at a
 # different location on Tier-1!
@@ -39,7 +41,7 @@ if [ ! -d "$ldas_dirname" ]; then
     cd $ldas_dirname
     mepo init
     mepo clone
-    cp $baselibs_root/g5_modules ./@env/
+    cp $baselibs_root/g5_modules_v7.7.0 ./@env/
 else
     echo "$ldas_dirname already exists. Skipping to build/install..."
     cd $ldas_dirname

--- a/GEOSldas/build_scripts/get_build_baselibs.bash
+++ b/GEOSldas/build_scripts/get_build_baselibs.bash
@@ -2,6 +2,7 @@
 
 #version=6.2.8 # working for tier-1 and tier-2
 version=6.2.13 # working only fier tier-1 currently (texinfo needed for 2021 tier-2 toolchain)
+version=7.7.0 # working only fier tier-1 currently (texinfo needed for 2021 tier-2 toolchain)
 
 # IMPORTANT: staging is not cross-mounted, so the baselibs are installed at a
 # different location on Tier-1!
@@ -53,7 +54,7 @@ rm -f ESMA-Baselibs-v${version}.COMPLETE.tar.xz
 cd $root/ESMA-Baselibs-v${version}
 
 # temporary fix since 6.2.13 baselibs were not complete: getting full FLAP from 6.2.8
-if [[ $version == "6.2.13" ]]; then
+if [[ $version == "6.2.13" ]] | [[ $version == "7.7.0" ]] ; then
     rm -r $root/ESMA-Baselibs-v${version}/FLAP
     mkdir $root/temp
     cd $root/temp
@@ -67,7 +68,7 @@ fi
 
 if [[ $version == "6.2.8" ]]; then
     cd $root/ESMA-Baselibs-v${version}/src
-elif [[ $version == "6.2.13" ]]; then
+elif [[ $version == "6.2.13" ]] | [[ $version == "7.7.0" ]] ; then
     cd $root/ESMA-Baselibs-v${version}
 fi
 mkdir Linux
@@ -82,7 +83,7 @@ fi
 export FC=gfortran
 if [[ $version == "6.2.8" ]]; then
     make install ESMF_COMM=openmpi prefix=$root/ESMA-Baselibs-v${version}/src/Linux
-elif [[ $version == "6.2.13" ]]; then
+elif [[ $version == "6.2.13" ]] | [[ $version == "7.7.0" ]]; then
     make install ESMF_COMM=openmpi prefix=$root/ESMA-Baselibs-v${version}/Linux
 fi
 


### PR DESCRIPTION
Hi Sebastian,
in case you need/want still to switch to 17.12.0 because of the tile id error.
Have a quick look at the PR and approve, then we merge the PR. The compilation ran through for me.
The right new baselibs are compiled already on /dodrio/scratch/projects/2022_200/project_input/rsda/ldas/GEOSldas_libraries/
You can directly use the get_build_GEOSldas to compile v17.12.0 (it loads the g5_modules_v7.7.0).
cheers, Michel